### PR TITLE
Reduce CPU time on HitWire.

### DIFF
--- a/Tiles/HighPriestess.cs
+++ b/Tiles/HighPriestess.cs
@@ -51,7 +51,10 @@ namespace Laugicality.Tiles
             for (int k = 0; k < 200; k++)
             {
                 if (Main.npc[k].boss && Main.npc[k].active)
+                {
                     boss = true;
+                    break;
+                }
             }
             if(!boss)
             {


### PR DESCRIPTION
When a boss is found, stop the loop as it no longer needs to run.